### PR TITLE
Change color section in stealthburner_leds.cfg

### DIFF
--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -52,22 +52,22 @@
 # configurations for the logo and nozzle here.
 variable_colors: {
         'logo': { # Colors for logo states
-            'busy': {'r': 0.4, 'g': 0.0, 'b': 0.0, 'w': 0.0},
-            'cleaning': {'r': 0.0, 'g': 0.02, 'b': 0.5, 'w': 0.0},
-            'calibrating_z': {'r': 0.8, 'g': 0., 'b': 0.35, 'w': 0.0},
-            'heating': {'r': 0.3, 'g': 0.18, 'b': 0.0, 'w': 0.0},
-            'homing': {'r': 0.0, 'g': 0.6, 'b': 0.2, 'w': 0.0},
-            'leveling': {'r': 0.5, 'g': 0.1, 'b': 0.4, 'w': 0.0},
-            'meshing': {'r': 0.2, 'g': 1.0, 'b': 0.0, 'w': 0.0},
+            'red_dim': {'r': 0.4, 'g': 0.0, 'b': 0.0, 'w': 0.0},
+            'cyan': {'r': 0.0, 'g': 0.02, 'b': 0.5, 'w': 0.0},
+            'pink_bright': {'r': 0.8, 'g': 0.0, 'b': 0.35, 'w': 0.0},
+            'yellow': {'r': 0.3, 'g': 0.18, 'b': 0.0, 'w': 0.0},
+            'green_bright': {'r': 0.0, 'g': 0.6, 'b': 0.2, 'w': 0.0},
+            'white_med': {'r': 0.5, 'g': 0.1, 'b': 0.4, 'w': 0.0},
+            'green_yellow': {'r': 0.2, 'g': 1.0, 'b': 0.0, 'w': 0.0},
             'off': {'r': 0.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
-            'printing': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
-            'standby': {'r': 0.01, 'g': 0.01, 'b': 0.01, 'w': 0.1},
+            'red_bright': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
+            'white_dim': {'r': 0.01, 'g': 0.01, 'b': 0.01, 'w': 0.1},
         },
         'nozzle': { # Colors for nozzle states
-            'heating': {'r': 0.8, 'g': 0.35, 'b': 0.0, 'w':0.0},
+            'orange_bright': {'r': 0.8, 'g': 0.35, 'b': 0.0, 'w':0.0},
             'off': {'r': 0.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
             'on': {'r': 0.8, 'g': 0.8, 'b': 0.8, 'w':1.0},
-            'standby': {'r': 0.6, 'g': 0.0, 'b': 0.0, 'w':0.0},
+            'red_med': {'r': 0.6, 'g': 0.0, 'b': 0.0, 'w':0.0},
         },
         'thermal': {
             'hot': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
@@ -164,6 +164,21 @@ gcode:
     {% set transmit=params.TRANSMIT|default(1) %}
     _set_sb_leds_by_name leds="nozzle" color="off" transmit={transmit}
 
+##############################################################################
+# You need to add the status macros to your macros when you want to call them
+# Change your status colors here
+
+# Example:
+# [gcode_macro print_start]
+# gcode:
+#     STATUS_HOMING
+#     G28
+#     STATUS_HEATING
+#     M140 S{bed_temp}
+#     M104 S{e0_temp}
+#     ...
+#     STATUS_PRINTING
+
 [gcode_macro status_off]
 gcode:
     set_logo_leds_off transmit=0
@@ -171,45 +186,45 @@ gcode:
 
 [gcode_macro status_ready]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="standby" transmit=0
-    _set_sb_leds_by_name leds="nozzle" color="standby" transmit=1
+    _set_sb_leds_by_name leds="logo" color="red_dim" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="red_med" transmit=1
 
 [gcode_macro status_busy]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="busy" transmit=0
+    _set_sb_leds_by_name leds="logo" color="red_dim" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_heating]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="heating" transmit=0
-    _set_sb_leds_by_name leds="nozzle" color="heating" transmit=1
+    _set_sb_leds_by_name leds="logo" color="yellow" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="orange_bright" transmit=1
 
 [gcode_macro status_leveling]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="leveling" transmit=0
+    _set_sb_leds_by_name leds="logo" color="white_med" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_homing]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="homing" transmit=0
+    _set_sb_leds_by_name leds="logo" color="green_bright" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_cleaning]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="cleaning" transmit=0
+    _set_sb_leds_by_name leds="logo" color="cyan" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_meshing]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="meshing" transmit=0
+    _set_sb_leds_by_name leds="logo" color="green_yellow" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_calibrating_z]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="calibrating_z" transmit=0
+    _set_sb_leds_by_name leds="logo" color="pink_bright" transmit=0
     set_nozzle_leds_on
 
 [gcode_macro status_printing]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="printing" transmit=0
+    _set_sb_leds_by_name leds="logo" color="red_bright" transmit=0
     set_nozzle_leds_on


### PR DESCRIPTION
Renamed the logo and nozzle colors to match the actual colors they create instead of status names. Changed status macros to match new names.

I found the color names confusing. Hard to tell what color the status macros are supposed to produce when used. I think the color variables would be more useful just being a list of actual colors to choose from. Makes it much easier to add more macros or change the preferred colors of the current ones.

For now, I only renamed the existing colors the best I could. I went with a _bright, _med, and _dim tags for multiples of the same color.

A later pull request would change it to a comprehensive list of colors. Which colors and variants would be included is TBD.

I also added an example for adding the status macros to the comments. Many people thought the macros would work automatically.