### PR TITLE
Clean up stealthburner_leds.cfg

### DIFF
--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -32,7 +32,7 @@
 #
 # The following status macros are available:
 #    STATUS_OFF                 ; All off
-#    STATUS_READY               ; Red logo and nozzle
+#    STATUS_READY               ; White logo and red nozzle
 #    STATUS_BUSY                ; Red logo and white nozzle
 #    STATUS_HEATING             ; Yellow logo and nozzle
 #    STATUS_LEVELING            ; Pink logo and white nozzle

--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -31,19 +31,33 @@
 # MACROS
 #
 # The following status macros are available:
-#    STATUS_READY
-#    STATUS_OFF
-#    STATUS_BUSY
-#    STATUS_HEATING
-#    STATUS_LEVELING
-#    STATUS_HOMING
-#    STATUS_CLEANING
-#    STATUS_MESHING
-#    STATUS_CALIBRATING_Z
+#    STATUS_OFF                 ; All off
+#    STATUS_READY               ; Red logo and nozzle
+#    STATUS_BUSY                ; Red logo and white nozzle
+#    STATUS_HEATING             ; Yellow logo and nozzle
+#    STATUS_LEVELING            ; Pink logo and white nozzle
+#    STATUS_HOMING              ; Cyan logo and white nozzle
+#    STATUS_CLEANING            ; Blue logo and white nozzle
+#    STATUS_MESHING             ; Green logo and white nozzle
+#    STATUS_CALIBRATING_Z       ; Magenta logo and white nozzle
+#    STATUS_PRINTING            ; Red logo and white nozzle
 # With additional macros for direct control:
 #    SET_NOZZLE_LEDS_ON
-#    SET_LOGO_LEDS_OFF
 #    SET_NOZZLE_LEDS_OFF
+#    SET_LOGO_LEDS_OFF
+#
+# You will need to add the status macros into your configuration before the matching command
+# 
+# Example:
+# [gcode_macro print_start]
+# gcode:
+#     STATUS_HOMING
+#     G28
+#     STATUS_HEATING
+#     M140 S{bed_temp}
+#     M104 S{e0_temp}
+#     ...
+#     STATUS_PRINTING
 #
 # Contributed by Voron discord users wile.e, Tetsunosuke, and etherwalker
 
@@ -52,22 +66,22 @@
 # configurations for the logo and nozzle here.
 variable_colors: {
         'logo': { # Colors for logo states
-            'busy': {'r': 0.4, 'g': 0.0, 'b': 0.0, 'w': 0.0},
-            'cleaning': {'r': 0.0, 'g': 0.02, 'b': 0.5, 'w': 0.0},
-            'calibrating_z': {'r': 0.8, 'g': 0., 'b': 0.35, 'w': 0.0},
-            'heating': {'r': 0.3, 'g': 0.18, 'b': 0.0, 'w': 0.0},
-            'homing': {'r': 0.0, 'g': 0.6, 'b': 0.2, 'w': 0.0},
-            'leveling': {'r': 0.5, 'g': 0.1, 'b': 0.4, 'w': 0.0},
-            'meshing': {'r': 0.2, 'g': 1.0, 'b': 0.0, 'w': 0.0},
             'off': {'r': 0.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
+            'ready': {'r': 0.01, 'g': 0.01, 'b': 0.01, 'w': 0.1},
+            'busy': {'r': 0.4, 'g': 0.0, 'b': 0.0, 'w': 0.0},
+            'heating': {'r': 0.3, 'g': 0.18, 'b': 0.0, 'w': 0.0},
+            'leveling': {'r': 0.5, 'g': 0.1, 'b': 0.4, 'w': 0.0},
+            'homing': {'r': 0.0, 'g': 0.6, 'b': 0.2, 'w': 0.0},
+            'cleaning': {'r': 0.0, 'g': 0.02, 'b': 0.5, 'w': 0.0},
+            'meshing': {'r': 0.2, 'g': 1.0, 'b': 0.0, 'w': 0.0},
+            'calibrating_z': {'r': 0.8, 'g': 0.0, 'b': 0.35, 'w': 0.0},
             'printing': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
-            'standby': {'r': 0.01, 'g': 0.01, 'b': 0.01, 'w': 0.1},
         },
         'nozzle': { # Colors for nozzle states
-            'heating': {'r': 0.8, 'g': 0.35, 'b': 0.0, 'w':0.0},
             'off': {'r': 0.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
             'on': {'r': 0.8, 'g': 0.8, 'b': 0.8, 'w':1.0},
-            'standby': {'r': 0.6, 'g': 0.0, 'b': 0.0, 'w':0.0},
+            'ready': {'r': 0.6, 'g': 0.0, 'b': 0.0, 'w':0.0},
+            'heating': {'r': 0.8, 'g': 0.35, 'b': 0.0, 'w':0.0},
         },
         'thermal': {
             'hot': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
@@ -171,8 +185,8 @@ gcode:
 
 [gcode_macro status_ready]
 gcode:
-    _set_sb_leds_by_name leds="logo" color="standby" transmit=0
-    _set_sb_leds_by_name leds="nozzle" color="standby" transmit=1
+    _set_sb_leds_by_name leds="logo" color="ready" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="ready" transmit=1
 
 [gcode_macro status_busy]
 gcode:


### PR DESCRIPTION
No functional changes have been made. Drop in replacement. Fixed a couple errors, added comments, added example, reordered lists to all match.

- STATUS_PRINTING was missing from list of macros, added.
- STATUS_READY referred to color 'standby', changed color name to 'ready' to match.
- Added instructions to use status macros and a print_start example.
- Changed order of colors to match list above and the macros themselves below.
- calibrating_z was missing a zero after the decimal for green. Changed to " 'g': 0.0, "