### PR TITLE
Set initial_RED to 1

### DIFF
--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -10,7 +10,7 @@
 # for Neopixels with a dedicated white LED. On startup, all three SB LEDs should light up.
 #
 # If you get random colors across your LEDs, change the color_order to GRB and restart. Then
-# ignore the W for each suggested color_order in the next paragraph.
+# omit the W for each suggested color_order in the next paragraph.
 #
 # If you get MAGENTA, your  color order is correct. If you get CYAN, you need to use RGBW. If
 # you get YELLOW, you need to use BRGW (note that BRG is only supported in the latest Klipper

--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -17,7 +17,7 @@
 # color_order: GRBW
 # #   Set the pixel order required by the LED hardware. Options are GRB,
 # #   RGB, GRBW, or RGBW. The default is GRB.
-# initial_RED: 0.0
+# initial_RED: 1.0
 # initial_GREEN: 0.0
 # initial_BLUE: 0.0
 # initial_WHITE: 0.0

--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -5,7 +5,17 @@
 #
 # CONFIGURATION
 #
-# Example neopixel configuration:
+# Example neopixel configuration. Note that we set RED and BLUE to 1.0 to make it easier for
+# users and supporters to detect misconfigurations or miswiring. The default color format is
+# for Neopixels with a dedicated white LED. On startup, all three SB LEDs should light up.
+#
+# If you get random colors across your LEDs, change the color_order to GRB and restart. Then
+# ignore the W for each suggested color_order in the next paragraph.
+#
+# If you get MAGENTA, your  color order is correct. If you get CYAN, you need to use RGBW. If
+# you get YELLOW, you need to use BRGW (note that BRG is only supported in the latest Klipper
+# version). 
+#
 # [neopixel sb_leds]
 # pin: <your pin>
 # #   The pin connected to the neopixel. This parameter must be
@@ -19,7 +29,7 @@
 # #   RGB, GRBW, or RGBW. The default is GRB.
 # initial_RED: 1.0
 # initial_GREEN: 0.0
-# initial_BLUE: 0.0
+# initial_BLUE: 1.0
 # initial_WHITE: 0.0
 # #   Sets the initial LED color of the Neopixel. Each value should be
 # #   between 0.0 and 1.0. The WHITE option is only available on RGBW


### PR DESCRIPTION
People complain about their Neopixels not working, not knowing that they need to call the macros before anything happens.

This PR is to set `initial_RED` to 1 to have a better out-of-the-box experience and less trouble for us supporters trying to figure out if the wiring is wrong or if people just don't know about the macros.