### PR TITLE
clarified heat set nut dimensions

### DIFF
--- a/BOM/voron_stealthburner_bom.csv
+++ b/BOM/voron_stealthburner_bom.csv
@@ -10,7 +10,7 @@ Fasteners,M3x50 SHCS,2,
 ,M3x6 FHCS,2,
 ,M3 Hexnut,2,
 ,Bondtech BMG Extruder Kit,1,
-,M3 Brass heatstake inserts - short M3x5x4,22,
+,M3 Brass heatstake inserts - short M3x5x4,22, M3 x D5.0 x L4.0 check actual dimensions
 Misc,3x6mm Magnet,1, for Hall Effect endstops
 Electronics,40x40x10 Axial Fan (24V),1,
 ,50x50x15 Centrifugal Fan (24V),1,


### PR DESCRIPTION
It's annoying when different vendors mixed up (L)ength and O(D) resulting in purchasing the wrong nuts. This note should go on every applicable sourcing guide. 